### PR TITLE
Support influx-style tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ The format of each metric is:
 
     <bucket name>:<value>|<type>\n
 
-* `<bucket name>` is a string like `abc.def.g`, just like a graphite bucket name
+* `<bucket name>` is a string like `abc.def.g`, just like a graphite bucket name.
+Influx-style tags are supported, i.e., `abc.def.g,a=b,foo=bar`.
 * `<value>` is a string representation of a floating point number
 * `<type>` is one of `c`, `g`, or `ms` for "counter", "gauge", and "timer"
 respectively.

--- a/statsd/metrics.go
+++ b/statsd/metrics.go
@@ -30,9 +30,10 @@ func (m MetricType) String() string {
 
 // Metric represents a single data collected datapoint
 type Metric struct {
-	Type   MetricType // The type of metric
-	Bucket string     // The name of the bucket where the metric belongs
-	Value  float64    // The numeric value of the metric
+	Type   MetricType        // The type of metric
+	Bucket string            // The name of the bucket where the metric belongs
+	Value  float64           // The numeric value of the metric
+	Tags   map[string]string // Influxdata tags extension
 }
 
 func (m Metric) String() string {

--- a/statsd/receiver_test.go
+++ b/statsd/receiver_test.go
@@ -1,33 +1,38 @@
 package statsd
 
 import (
+	"reflect"
 	"testing"
 )
 
 func TestParseLine(t *testing.T) {
 	tests := map[string]Metric{
-		"foo.bar.baz:2|c": Metric{Bucket: "foo.bar.baz", Value: 2.0, Type: COUNTER},
-		"abc.def.g:3|g":   Metric{Bucket: "abc.def.g", Value: 3, Type: GAUGE},
-		"def.g:10|ms":     Metric{Bucket: "def.g", Value: 10, Type: TIMER},
+		"foo.bar.baz:2|c":       Metric{Bucket: "foo.bar.baz", Value: 2.0, Type: COUNTER},
+		"abc.def.g:3|g":         Metric{Bucket: "abc.def.g", Value: 3, Type: GAUGE},
+		"def.g:10|ms":           Metric{Bucket: "def.g", Value: 10, Type: TIMER},
+		"asdf,x=y,foo=bar:10|c": Metric{Bucket: "asdf", Value: 10, Type: COUNTER, Tags: map[string]string{"x": "y", "foo": "bar"}},
+		"asdf,asdf,x=y:1|c":     Metric{Bucket: "asdf", Value: 1, Type: COUNTER, Tags: map[string]string{"x": "y"}},
 	}
 
 	for input, expected := range tests {
-		result, err := parseLine([]byte(input))
-		if err != nil {
-			t.Errorf("test %s error: %s", input, err)
-			continue
-		}
-		if result != expected {
-			t.Errorf("test %s: expected %s, got %s", input, expected, result)
-			continue
-		}
+		t.Run(input, func(t *testing.T) {
+			result, err := parseLine([]byte(input))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(result, expected) {
+				t.Errorf("expected %s, got %s", expected, result)
+			}
+		})
 	}
 
 	failing := []string{"fOO|bar:bazkk", "foo.bar.baz:1|q"}
 	for _, tc := range failing {
-		result, err := parseLine([]byte(tc))
-		if err == nil {
-			t.Errorf("test %s: expected error but got %s", tc, result)
-		}
+		t.Run(tc, func(t *testing.T) {
+			result, err := parseLine([]byte(tc))
+			if err == nil {
+				t.Errorf("expected error but got %s", result)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Extends the parsing logic to extract tags out of the bucket name.

Signed-off-by: Eric Chlebek <eric@sensu.io>